### PR TITLE
Docker build

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,9 +29,9 @@ If they don't, this triggers an alert (and a prompt to force update the WHOIS re
 ## Installation
 
 ### Docker
-See github package release (sidebar link) for versioned docker images and instructions for pulling.
+Current docker images are hosted on [Github Packages](https://github.com/nwesterhausen/domain-monitor/packages/).
 
-The docker image exposes one port, 4201 TCP.
+The *server* image is the main image.
 
 The docker image uses two volumes, be aware if you want to manually edit the configs or
 view the cached whois data.
@@ -40,6 +40,10 @@ Image Mount     | Contains
 ------------    | ------------
 /app/config     | config.yaml and domain.yaml
 /app/whois-data | cached whois data in yaml files
+
+Exposed Ports   | Use
+------------    | ----------
+4201/tcp        | WEB GUI
 
 ### Running with node
 Should by OS agnostic. Requires nodejs >= 12

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Image Mount     | Contains
 /app/config     | config.yaml and domain.yaml
 /app/whois-data | cached whois data in yaml files
 
-Exposed Ports   | Use
+Exposed Ports   | Used for
 ------------    | ----------
 4201/tcp        | WEB GUI
 

--- a/README.md
+++ b/README.md
@@ -29,9 +29,6 @@ If they don't, this triggers an alert (and a prompt to force update the WHOIS re
 ## Installation
 
 ### Docker
-Current docker images are hosted on [Github Packages](https://github.com/nwesterhausen/domain-monitor/packages/).
-
-The *server* image is the main image.
 
 The docker image uses two volumes, be aware if you want to manually edit the configs or
 view the cached whois data.
@@ -44,6 +41,15 @@ Image Mount     | Contains
 Exposed Ports   | Used for
 ------------    | ----------
 4201/tcp        | WEB GUI
+
+
+#### Using [Github Packages](https://github.com/nwesterhausen/domain-monitor/packages/)
+
+The *server* image is the main image.
+
+#### Using [Docker Hub](https://hub.docker.com/repository/docker/nwesterhausen/domain-monitor)
+
+Image is just `nwesterhausen/domain-monitor`, latest tag will be the most recent version, or pull by tagged version.
 
 ### Running with node
 Should by OS agnostic. Requires nodejs >= 12

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+#
+# Automatically docker build and tag for current version
+# Then upload to GH Packages
+#
+# Requires jq and ~/.gh_token
+
+# Github Username
+USERNAME=nwesterhausen
+# Get repo part of repository
+IMAGE_PREFIX=$(jq .repository.url package.json | cut -d/ -f 5 | cut -d. -f 1)
+# Name for this image
+IMAGE=server
+# Get version tag from package.json
+TAG=$(jq .version package.json)
+
+# Concat strings
+VERSIONED_TAG="docker.pkg.github.com/$USERNAME/$IMAGE_PREFIX/$IMAGE:$TAG"
+LATEST_TAG="docker.pkg.github.com/$USERNAME/$IMAGE_PREFIX/$IMAGE:latest"
+
+# Build the docker image
+docker build -t "$VERSIONED_TAG" .
+
+# Also build a latest
+docker build -t "$LATEST_TAG" .
+
+# Login to gh packages docker repo
+cat ~/.gh_token | docker login docker.pkg.github.com -u nwesterhausen --password-stdin
+
+# Push the images
+docker push "$VERSIONED_TAG"
+docker push "$LATEST_TAG"

--- a/build.sh
+++ b/build.sh
@@ -12,21 +12,26 @@ IMAGE_PREFIX=$(jq .repository.url package.json | cut -d/ -f 5 | cut -d. -f 1)
 # Name for this image
 IMAGE=server
 # Get version tag from package.json
-TAG=$(jq .version package.json)
+TAG=$(jq .version package.json | cut -d\" -f 2)
 
 # Concat strings
 VERSIONED_TAG="docker.pkg.github.com/$USERNAME/$IMAGE_PREFIX/$IMAGE:$TAG"
-LATEST_TAG="docker.pkg.github.com/$USERNAME/$IMAGE_PREFIX/$IMAGE:latest"
 
 # Build the docker image
-docker build -t "$VERSIONED_TAG" .
+docker build -t "$USERNAME/$IMAGE_PREFIX" .
 
-# Also build a latest
-docker build -t "$LATEST_TAG" .
+# Grab the image ID
+IMAGE_ID=$(docker images -q "$USERNAME/$IMAGE_PREFIX")
+echo $IMAGE_ID
+
+# Tag the image
+docker tag $IMAGE_ID "$VERSIONED_TAG"
 
 # Login to gh packages docker repo
 cat ~/.gh_token | docker login docker.pkg.github.com -u nwesterhausen --password-stdin
 
 # Push the images
 docker push "$VERSIONED_TAG"
-docker push "$LATEST_TAG"
+
+# You could then go on to include other docker package repositories here,
+# by tagging and pushing as appropriate.

--- a/build.sh
+++ b/build.sh
@@ -16,17 +16,20 @@ TAG=$(jq .version package.json | cut -d\" -f 2)
 
 # Concat strings
 GH_TAGBASE="docker.pkg.github.com/$USERNAME/$IMAGE_PREFIX/$IMAGE"
+DOCKER_TAGBASE="$USERNAME/$IMAGE_PREFIX"
 
 # Build the docker image
-docker build -t "$USERNAME/$IMAGE_PREFIX" .
+docker build -t "$DOCKER_TAGBASE" .
 
 # Grab the image ID
-IMAGE_ID=$(docker images -q "$USERNAME/$IMAGE_PREFIX")
+IMAGE_ID=$(docker images -q "$DOCKER_TAGBASE")
 echo $IMAGE_ID
 
 # Tag the image
 docker tag $IMAGE_ID "$GH_TAGBASE:$TAG"
 docker tag $IMAGE_ID "$GH_TAGBASE:latest"
+docker tag $IMAGE_ID "$DOCKER_TAGBASE:$TAG"
+docker tag $IMAGE_ID "$DOCKER_TAGBASE:latest"
 
 # Login to gh packages docker repo
 cat ~/.gh_token | docker login docker.pkg.github.com -u nwesterhausen --password-stdin
@@ -34,6 +37,13 @@ cat ~/.gh_token | docker login docker.pkg.github.com -u nwesterhausen --password
 # Push the images
 docker push "$GH_TAGBASE:$TAG"
 docker push "$GH_TAGBASE:latest"
+
+# Login to docker.io
+docker login
+
+# Push the images
+docker push "$DOCKER_TAGBASE:$TAG"
+docker push "$DOCKER_TAGBASE:latest"
 
 # You could then go on to include other docker package repositories here,
 # by tagging and pushing as appropriate.

--- a/build.sh
+++ b/build.sh
@@ -15,7 +15,7 @@ IMAGE=server
 TAG=$(jq .version package.json | cut -d\" -f 2)
 
 # Concat strings
-VERSIONED_TAG="docker.pkg.github.com/$USERNAME/$IMAGE_PREFIX/$IMAGE:$TAG"
+GH_TAGBASE="docker.pkg.github.com/$USERNAME/$IMAGE_PREFIX/$IMAGE"
 
 # Build the docker image
 docker build -t "$USERNAME/$IMAGE_PREFIX" .
@@ -25,13 +25,15 @@ IMAGE_ID=$(docker images -q "$USERNAME/$IMAGE_PREFIX")
 echo $IMAGE_ID
 
 # Tag the image
-docker tag $IMAGE_ID "$VERSIONED_TAG"
+docker tag $IMAGE_ID "$GH_TAGBASE:$TAG"
+docker tag $IMAGE_ID "$GH_TAGBASE:latest"
 
 # Login to gh packages docker repo
 cat ~/.gh_token | docker login docker.pkg.github.com -u nwesterhausen --password-stdin
 
 # Push the images
-docker push "$VERSIONED_TAG"
+docker push "$GH_TAGBASE:$TAG"
+docker push "$GH_TAGBASE:latest"
 
 # You could then go on to include other docker package repositories here,
 # by tagging and pushing as appropriate.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "domain-monitor",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Node-js server for monitoring domain WHOIS records.",
   "main": "index.js",
   "repository": {


### PR DESCRIPTION
Created a bash build script to make creating updated docker images easier. It references the package.json for the version so as long as that is kept up to date, the images will be tagged accurately.

Wanted to not use the repo name again as the image tag, it was really redundant (nwesterhausen/domain-monitor/domain-monitor) but maybe I was overthinking it. Using 'server' as the tag (so it's nwesterhausen/domain-monitor/server).