### PR TITLE
Fix/domain name

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "domain-monitor",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "Node-js server for monitoring domain WHOIS records.",
   "main": "server/index.js",
   "repository": {

--- a/server/lib/whois-manager.js
+++ b/server/lib/whois-manager.js
@@ -224,12 +224,9 @@ function simplifyWhois(whoisdata) {
     );
 
     const tmpWhoisObject = whoisdata.split(/\n/);
-    let rootkey = "",
-      currkey = "";
+    let rootkey = "";
     for (let i = 0; i < tmpWhoisObject.length; i++) {
       const matched = tmpWhoisObject[i].match(ATTRIBUTE_REGEX);
-
-      currkey = tmpWhoisObject[i].match(ATTRIBUTE_REGEX);
       if (/:$/.test(tmpWhoisObject[i])) {
         // console.debug("Matched rootkey");
         rootkey = tmpWhoisObject[i].split(":")[0];

--- a/server/lib/whois-manager.js
+++ b/server/lib/whois-manager.js
@@ -286,6 +286,7 @@ function simplifyWhois(whoisdata) {
           simplifiedObject.domain_status.push(matched[2]);
           break;
         case "Name Server":
+        case "Name servers":
           simplifiedObject.name_server.push(matched[2]);
           break;
         case "Reseller":
@@ -420,5 +421,15 @@ function simplifyWhois(whoisdata) {
       simplifiedObject.tos = whoisObject[i];
     }
   }
+  if (!simplifiedObject.domain_name) {
+    console.error(`No domain name found in whois response.`);
+    return {};
+  }
+  if (simplifiedObject.name_server.length == 0) {
+    console.warn(
+      `${simplifiedObject.doamin_name} WHOIS: unable to parse name servers.`
+    );
+  }
+
   return simplifiedObject;
 }

--- a/server/lib/whois-manager.js
+++ b/server/lib/whois-manager.js
@@ -237,9 +237,10 @@ function simplifyWhois(whoisdata) {
   for (let i = 0; i < whoisObject.length; i++) {
     const matched = whoisObject[i].match(ATTRIBUTE_REGEX);
     if (matched && matched.length > 1) {
-      switch (matched[1]) {
+      switch (matched[1].trim()) {
         case "Domain name":
         case "Domain Name":
+        case "Domain":
           simplifiedObject.domain_name = matched[2].toLowerCase();
           break;
         case "Registry Domain ID":

--- a/server/lib/whois-manager.js
+++ b/server/lib/whois-manager.js
@@ -468,7 +468,12 @@ function simplifyWhois(whoisdata) {
       `${simplifiedObject.doamin_name} WHOIS: unable to parse name servers.`
     );
   }
-
+  if (!simplifiedObject.whois_db_update_time) {
+    console.warn(
+      "WHOIS query did not attached a timestamp, using current time."
+    );
+    simplifiedObject.whois_db_update_time = new Date().toISOString();
+  }
   return simplifiedObject;
 }
 


### PR DESCRIPTION
addresses the .eu domain breaking things #22 

Does some pre-processing when the format of the WHOIS response matches the troublesome one causing things to break with the .eu domain. (i.e. key-values with indents instead of listing things one per line).