### PR TITLE
fix: :bug: parser getting stuck on CRLF

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "domain-monitor",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "Node-js server for monitoring domain WHOIS records.",
   "main": "server/index.js",
   "repository": {

--- a/server/lib/whois-manager.js
+++ b/server/lib/whois-manager.js
@@ -259,7 +259,7 @@ function simplifyWhois(whoisdata) {
     console.error(whoisdata);
   }
   if (Object.keys(whoisObject).length <= 10) {
-    console.error("Parsing seems to have failed, writing dump.")
+    console.error("Parsing seems to have failed, writing dump.");
     fs.writeFile("./whois.dump", whoisdata);
     return { raw: whoisdata };
   }

--- a/server/lib/whois-manager.js
+++ b/server/lib/whois-manager.js
@@ -216,6 +216,8 @@ function writeWhoisData(ypath, whoisObj) {
  */
 function simplifyWhois(whoisdata) {
   console.info(`${typeof whoisdata} received.`, whoisdata);
+  // Clean CRLF into LF
+  whoisdata = whoisdata.replace(/\r\n/g, "\n");
 
   const whoisObject = [];
   if (/:\n/.test(whoisdata)) {
@@ -257,6 +259,8 @@ function simplifyWhois(whoisdata) {
     console.error(whoisdata);
   }
   if (Object.keys(whoisObject).length <= 10) {
+    console.error("Parsing seems to have failed, writing dump.")
+    fs.writeFile("./whois.dump", whoisdata);
     return { raw: whoisdata };
   }
   const simplifiedObject = {


### PR DESCRIPTION
The retrieved WHOIS data had CRLF and this seemed to prevent the split function from working correctly. Now there's a step before the split where CRLF is replaced with LF and things began to work again. Fixes #33

fubar.com registrar was godaddy.com but the issue may also have come up from running on WSL on windows instead of a purely linux environment.