### PR TITLE
Fixes expiry dates being unknown for .dev domains

### DIFF
--- a/server/lib/whois-manager.js
+++ b/server/lib/whois-manager.js
@@ -319,6 +319,7 @@ function simplifyWhois(whoisdata) {
           simplifiedObject.created_date = matched[2];
           break;
         case "Registrar Registration Expiration Date":
+        case "Registry Expiry Date":
           simplifiedObject.registrar.registration_expiration = matched[2];
           break;
         case "Registrar":

--- a/server/lib/yamler.js
+++ b/server/lib/yamler.js
@@ -13,7 +13,7 @@ const WHOIS_DIR_PATH = path.join(__dirname, "..", "whois-data");
 function parseObjectFromYaml(yamldoc) {
   const promisedObject = function (resolve, reject) {
     try {
-      resolve(yaml.safeLoad(yamldoc));
+      resolve(yaml.load(yamldoc));
     } catch (e) {
       console.error(`YAML: Unable to parse from doc:`);
       console.error(yamldoc);
@@ -29,7 +29,7 @@ function parseObjectFromYaml(yamldoc) {
  * @return {string}
  */
 function parseYamlFromObj(obj) {
-  return yaml.safeDump(obj);
+  return yaml.dump(obj);
 }
 
 module.exports = {


### PR DESCRIPTION
Google's .dev domains provide the expiry date as "Registry Expiry Date" which was not being identified by the whois manager.

Also changes usages of js-yaml to no longer use deprecated safe methods that caused breakages after the pnpm change https://github.com/nwesterhausen/domain-monitor/commit/f81a45b1ad34fc9d7833bc488d67be4a4620b36f