### PR TITLE
Improvements

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,7 @@
+// Workspace settings
+{
+  "files.exclude": {
+    "**/*_templ.go": true,
+    "node_modules/": true,
+  }
+}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -70,9 +70,9 @@ func main() {
 	app.Use(middleware.Logger())
 
 	// set up our routes
-	handlers.SetupRoutes(app)
+	handlers.SetupRoutes(app, config.Config.App.ShowConfiguration)
 	handlers.SetupConfigRoutes(app, config)
-	handlers.SetupDomainRoutes(app, domains)
+	handlers.SetupDomainRoutes(app, domains, config.Config.App.ShowConfiguration)
 
 	// if the mailer was configured, add the routes
 	if _mailer != nil {

--- a/configuration/app.configuration.go
+++ b/configuration/app.configuration.go
@@ -13,6 +13,8 @@ type AppConfiguration struct {
 	Port int `yaml:"port" json:"port" default:"3124"`
 	// Allow automtic WHOIS refresh
 	AutomateWHOISRefresh bool `yaml:"automateWHOISRefresh" json:"automateWHOISRefresh" default:"true"`
+	// Show the configuration in the web interface. This is a security risk and should be disabled in production
+	ShowConfiguration bool `yaml:"showConfiguration" json:"showConfiguration" default:"false"`
 }
 
 type AlertsConfiguration struct {
@@ -95,6 +97,7 @@ func DefaultConfiguration(filepath string) Configuration {
 			App: AppConfiguration{
 				Port:                 3124,
 				AutomateWHOISRefresh: true,
+				ShowConfiguration:    true,
 			},
 			Scheduler: SchedulerConfiguration{
 				WhoisCacheStaleInterval:         190,

--- a/handlers/base.handler.go
+++ b/handlers/base.handler.go
@@ -5,6 +5,10 @@ import (
 	"github.com/nwesterhausen/domain-monitor/views/layout"
 )
 
-func HandlerShowBase(c echo.Context) error {
-	return View(c, layout.Base())
+type BaseHandler struct {
+	IncludeConfiguration bool
+}
+
+func (bh *BaseHandler) HandlerShowBase(c echo.Context) error {
+	return View(c, layout.Base(bh.IncludeConfiguration))
 }

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.1.0",
+  "version": "1.2.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/nwesterhausen/domain-monitor"

--- a/views/configuration/configuration.templ
+++ b/views/configuration/configuration.templ
@@ -10,19 +10,18 @@ templ Configuration() {
         <div>
             <h1 class="text-xl text-secondary">Configuration</h1>
             <p class="p-2">
-            Changes here are applied to the two config files located in a config dir where you run this server. If you want to
-            modify those files directly, changes will be realized upon restarting the server. Committing changes using this
-            configuration page will cause the server to restart so whatever changes you make take immediate effect.
+            Changes here are applied to the two config files located in a config dir where you run this server (<code>domain.yaml</code> and <code>config.yaml</code>).
+            After making changes, you will need to restart the server for them to take effect.
             </p>
         </div>
         <div role="tablist" class="tabs tabs-boxed">
-            <a role="tab" hx-target="#tabContent" hx-get="/config/domain" class="transition-color tab config-tab tab-active" _="on click remove .tab-active from .config-tab then add .tab-active to me">Domains</a>
-            <a role="tab" hx-target="#tabContent" hx-get="/config/app" class="transition-color tab config-tab" _="on click remove .tab-active from .config-tab then add .tab-active to me">Application</a>
+            <a role="tab" hx-target="#tabContent" hx-get="/config/app" class="transition-color tab config-tab tab-active" _="on click remove .tab-active from .config-tab then add .tab-active to me">Application</a>
+            <a role="tab" hx-target="#tabContent" hx-get="/config/domain" class="transition-color tab config-tab " _="on click remove .tab-active from .config-tab then add .tab-active to me">Domains</a>
             <a role="tab" hx-target="#tabContent" hx-get="/config/alerts" class="transition-color tab config-tab" _="on click remove .tab-active from .config-tab then add .tab-active to me">Alerts</a>
             <a role="tab" hx-target="#tabContent" hx-get="/config/smtp" class="transition-color tab config-tab" _="on click remove .tab-active from .config-tab then add .tab-active to me">SMTP</a>
             <a role="tab" hx-target="#tabContent" hx-get="/config/scheduler" class="transition-color tab config-tab" _="on click remove .tab-active from .config-tab then add .tab-active to me">Scheduler</a>
         </div>
-        <div id="tabContent" class="p-2 mt-3" hx-get="/config/domain" hx-trigger="load"></div>
+        <div id="tabContent" class="p-2 mt-3" hx-get="/config/app" hx-trigger="load"></div>
     </div>
 }
 
@@ -73,7 +72,14 @@ templ AppTab(conf configuration.AppConfiguration) {
             />
           </label>
         </div>
-        <button class="btn btn-xs btn-outline btn-success max-w-md ms-8">Save</button>
+        <div class="form-control max-w-md">
+          <label class="label cursor-pointer">
+            <span class="label-text">Allow Configuration from Web GUI</span>
+            <input type="checkbox" name="value" class="toggle toggle-success" checked?={conf.ShowConfiguration}
+            hx-post="/api/config/app/showConfiguration" hx-trigger="click throttle:10ms" hx-inclue="this"
+            />
+          </label>
+        </div>
         </div>
     </div>
 }

--- a/views/configuration/configuration.templ
+++ b/views/configuration/configuration.templ
@@ -95,7 +95,7 @@ templ AlertsTab(conf configuration.AlertsConfiguration) {
             <div class="label">
                 <span class="label-text">Admin Email</span>
             </div>
-            <input type="text" placeholder="smtp.example.com" class="input input-bordered w-full max-w-lg" value={conf.Admin} name="value" />
+            <input type="text" placeholder="admin@example.com" class="input input-bordered w-full max-w-lg" value={conf.Admin} name="value" />
             <div class="label">
                 <span class="label-text-alt">The email that any alerts should be sent to</span>
             </div>
@@ -167,7 +167,8 @@ templ SmtpTab(conf configuration.SMTPConfiguration) {
             <div class="label">
                 <span class="label-text">SMTP Host</span>
             </div>
-            <input type="text" placeholder="smtp.example.com" class="input input-bordered w-full max-w-lg" value={conf.Host} />
+            <input type="text" placeholder="smtp.example.com" class="input input-bordered w-full max-w-lg" value={conf.Host}  name="value"
+            hx-post="/api/config/smtp/host" hx-trigger="input throttle:500ms" hx-inclue="this"/>
             <div class="label">
                 <span class="label-text-alt">The SMTP hostname (or IP address)</span>
             </div>
@@ -176,7 +177,8 @@ templ SmtpTab(conf configuration.SMTPConfiguration) {
             <div class="label">
                 <span class="label-text">SMTP Port</span>
             </div>
-            <input type="text" placeholder="25" class="input input-bordered w-full max-w-lg" value={strconv.Itoa(conf.Port)} />
+            <input type="text" placeholder="25" class="input input-bordered w-full max-w-lg" value={strconv.Itoa(conf.Port)} name="value"
+            hx-post="/api/config/smtp/host" hx-trigger="input throttle:500ms" hx-inclue="this" />
             <div class="label">
                 <span class="label-text-alt">The SMTP port to connect to</span>
             </div>
@@ -192,7 +194,8 @@ templ SmtpTab(conf configuration.SMTPConfiguration) {
             <div class="label">
                 <span class="label-text">SMTP Username</span>
             </div>
-            <input type="text" placeholder="smtpuser" class="input input-bordered w-full max-w-lg" value={conf.AuthUser} />
+            <input type="text" placeholder="smtpuser" class="input input-bordered w-full max-w-lg" value={conf.AuthUser}  name="value"
+            hx-post="/api/config/smtp/authUser" hx-trigger="input throttle:500ms" hx-inclue="this" />
             <div class="label">
                 <span class="label-text-alt">Username if required to login to SMTP server</span>
             </div>
@@ -201,7 +204,8 @@ templ SmtpTab(conf configuration.SMTPConfiguration) {
             <div class="label">
                 <span class="label-text">SMTP Password</span>
             </div>
-            <input type="password" placeholder="" class="input input-bordered w-full max-w-lg" value={conf.AuthPass} />
+            <input type="password" placeholder="" class="input input-bordered w-full max-w-lg" value={conf.AuthPass} name="value"
+            hx-post="/api/config/smtp/authPass" hx-trigger="input throttle:500ms" hx-inclue="this" />
             <div class="label">
                 <span class="label-text-alt">Password if required to login to SMTP server</span>
             </div>
@@ -210,7 +214,8 @@ templ SmtpTab(conf configuration.SMTPConfiguration) {
             <div class="label">
                 <span class="label-text">From Name</span>
             </div>
-            <input type="text" placeholder="Domain Monitor" class="input input-bordered w-full max-w-lg" value={conf.FromName} />
+            <input type="text" placeholder="Domain Monitor" class="input input-bordered w-full max-w-lg" value={conf.FromName} name="value"
+            hx-post="/api/config/smtp/fromName" hx-trigger="input throttle:500ms" hx-inclue="this" />
             <div class="label">
                 <span class="label-text-alt">Name to use in the from field for email messages</span>
             </div>
@@ -219,12 +224,12 @@ templ SmtpTab(conf configuration.SMTPConfiguration) {
             <div class="label">
                 <span class="label-text">From Address</span>
             </div>
-            <input type="text" placeholder="monitor@domains.example.com" class="input input-bordered w-full max-w-lg" value={conf.FromAddress} />
+            <input type="text" placeholder="monitor@domains.example.com" class="input input-bordered w-full max-w-lg" value={conf.FromAddress} name="value"
+            hx-post="/api/config/smtp/fromAddress" hx-trigger="input throttle:500ms" hx-inclue="this" />
             <div class="label">
                 <span class="label-text-alt">Email address to use in the from field for messages</span>
             </div>
         </label>
-        <button class="btn btn-xs btn-outline btn-success max-w-md ms-8">Save</button>
         </div>
     </div>
 }

--- a/views/layout/base.layout.templ
+++ b/views/layout/base.layout.templ
@@ -2,7 +2,7 @@ package layout
 
 import "github.com/nwesterhausen/domain-monitor/views/modal"
 
-templ Base() {
+templ Base(includeConfig bool) {
 <!DOCTYPE html>
 <html lang="en" data-theme="fantasy">
 <head>
@@ -22,7 +22,7 @@ templ Base() {
 </head>
 <body>
 <div class="container-fluid">
-    @Navigation()
+    @Navigation(includeConfig)
     <div class="container-fluid" id="content">
     <div hx-get="/dashboard" hx-trigger="load">
     <p class="htmx-indicator">
@@ -35,4 +35,11 @@ templ Base() {
 </div>
 </body>
 </html>
+}
+
+templ BaseWithConfig() {
+    @Base(true)
+}
+templ BaseWithoutConfig() {
+    @Base(false)
 }

--- a/views/layout/navigation.layout.templ
+++ b/views/layout/navigation.layout.templ
@@ -1,6 +1,6 @@
 package layout
 
-templ Navigation() {
+templ Navigation(withConfiguration bool) {
 <div class="navbar bg-base-100">
   <div class="navbar-start">
     <span class="text-xl">Domain Monitor</span>
@@ -13,10 +13,16 @@ templ Navigation() {
         Loading <span class="loading loading-dots loading-xs"></span>
     </div>
   </div>
+    if withConfiguration {
+      @ConfigurationButton()
+    }
+</div>
+}
+
+templ ConfigurationButton() {
   <div class="navbar-end">
     <ul class="menu menu-horizontal px-1">
       <li><a hx-get="/configuration" hx-indicator="#loading-indication" hx-target="#content">Configuration</a></li>
     </ul>
   </div>
-</div>
 }


### PR DESCRIPTION
Fixes an issue where SMTP settings would not save if entered in the web UI.

Adds a configuration option to disable configuration via the web UI (or API). It is configured by default to allow configuration editing in the web UI (which matches current behavior). But by setting the `showConfiguration` in the `app` section to `false` (**and restarting the server**) will completely disable any editing of configuration in the web UI. This includes:

- Editing any configuration values
- Adding, updating, or removing domains
- Reading SMTP configuration
- Reading the admin email for alerts

This _should_ cover all instances of info that you wouldn't want leaking; of course, all the domains on the dashboard are visible with the data included there. This is more to lock the configuration and not allow any visitor to change settings or read sensitive settings.